### PR TITLE
Sanitize message links and secure external navigation

### DIFF
--- a/src/app/components/contact/contact.component.ts
+++ b/src/app/components/contact/contact.component.ts
@@ -52,13 +52,21 @@ export class ContactComponent implements OnInit {
     this.message = localMessage ? localMessage : undefined;
   }
 
+  private getEncodedMessage(): string {
+    return encodeURIComponent(this.message ?? this.constants.MESSAGE_DEFAULT);
+  }
+
   private sendWhatsapp() {
-    const link = this.constants.WHATSAPP_BASE + this.constants.MESSAGE_CONNECTOR + (this.message !== undefined ? this.message : this.constants.MESSAGE_DEFAULT);
+    const link = this.constants.WHATSAPP_BASE +
+      this.constants.MESSAGE_CONNECTOR +
+      this.getEncodedMessage();
     this.navigationService.openExternal(link);
   }
 
   private sendEmail() {
-    const link = this.constants.EMAIL_BASE + this.constants.MESSAGE_CONNECTOR + (this.message !== undefined ? this.message : this.constants.MESSAGE_DEFAULT);
+    const link = this.constants.EMAIL_BASE +
+      this.constants.MESSAGE_CONNECTOR +
+      this.getEncodedMessage();
     this.navigationService.openExternal(link);
   }
 

--- a/src/app/shared/services/navigation.service.ts
+++ b/src/app/shared/services/navigation.service.ts
@@ -18,7 +18,17 @@ export class NavigationService {
   }
 
   openExternal(url: string) {
-    window.open(url, "_blank");
+    try {
+      const parsed = new URL(url);
+      const allowedProtocols = ['http:', 'https:', 'mailto:'];
+      if (allowedProtocols.includes(parsed.protocol)) {
+        window.open(parsed.href, '_blank', 'noopener,noreferrer');
+      } else {
+        console.warn(`Blocked navigation to disallowed protocol: ${parsed.protocol}`);
+      }
+    } catch (err) {
+      console.error('Invalid URL', err);
+    }
   }
 
 }


### PR DESCRIPTION
## Summary
- Encode user-provided messages before composing contact links to prevent injection.
- Validate and harden external navigation by checking URL protocol and opening with `noopener,noreferrer`.

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689f331e50908326b54f3f4ca8088cda